### PR TITLE
Add test for user-friendly error when exporting YAML to a nonexistent directory

### DIFF
--- a/tests/bdd/features/format.feature
+++ b/tests/bdd/features/format.feature
@@ -425,6 +425,20 @@ Feature: Custom formats
         | basic_folder.yaml    |
         # | basic_dayone.yaml    |
 
+    Scenario Outline: Exporting YAML to nonexistent directory leads to user-friendly error with no traceback
+        Given we use the config "<config_file>"
+        And we use the password "test" if prompted
+        When we run "jrnl --export yaml --file nonexistent_dir"
+        Then the output should contain "YAML export must be to individual files"
+        And the output should not contain "Traceback"
+
+        Examples: configs
+        | config_file          |
+        | basic_onefile.yaml   |
+        | basic_encrypted.yaml |
+        | basic_folder.yaml    |
+        # | basic_dayone.yaml    | @todo
+
     @skip_win # @todo YAML exporter does not correctly export emoji on Windows
     Scenario Outline: Add a blank line to YAML export if there isn't one already
         # https://github.com/jrnl-org/jrnl/issues/768


### PR DESCRIPTION
Hi there @apainintheneck, I'm just adding a test for [your recent jrnl PR](https://github.com/jrnl-org/jrnl/pull/1449).

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
